### PR TITLE
moved x-api-key header to the proxy definition in vite.config.ts and …

### DIFF
--- a/03-sveltekit-chrome-devtool/.env.example
+++ b/03-sveltekit-chrome-devtool/.env.example
@@ -1,0 +1,1 @@
+API_KEY=<insert-api-key-here>

--- a/03-sveltekit-chrome-devtool/README.md
+++ b/03-sveltekit-chrome-devtool/README.md
@@ -8,6 +8,16 @@ This is a very simple sveltekit project. For this exercise, the only thing you n
 # To install project dependencies, please do:
 npm install
 
+# Setup
+In order to keep the API_KEY "secret", we write it into a special file called `.env` in this folder. Create that file and put in the following:
+
+```
+API_KEY=xxxxxx
+```
+
+Replace xxxxxxx with the API_KEY that we shared elsewhere. Doing it this way (instead of writing the value into the code directly) prevents that API_KEYs and other secret information is being stored in the source code repo. The file `.env` is ignored during git commit and push operations(see file `.gitignore`).
+
+
 # To run app, please do:
 npm run dev
 ```

--- a/03-sveltekit-chrome-devtool/package-lock.json
+++ b/03-sveltekit-chrome-devtool/package-lock.json
@@ -14,6 +14,7 @@
 				"@sveltejs/adapter-auto": "^3.0.0",
 				"@sveltejs/kit": "^2.0.0",
 				"@sveltejs/vite-plugin-svelte": "^4.0.0",
+				"@types/node": "^22.9.0",
 				"svelte": "^5.1.3",
 				"svelte-check": "^4.0.0",
 				"typescript": "^5.0.0",
@@ -837,6 +838,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/node": {
+			"version": "22.9.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+			"integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.19.8"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.14.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -1395,6 +1406,13 @@
 			"engines": {
 				"node": ">=14.17"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.19.8",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/vite": {
 			"version": "5.4.10",

--- a/03-sveltekit-chrome-devtool/package.json
+++ b/03-sveltekit-chrome-devtool/package.json
@@ -13,6 +13,7 @@
 		"@sveltejs/adapter-auto": "^3.0.0",
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^4.0.0",
+		"@types/node": "^22.9.0",
 		"svelte": "^5.1.3",
 		"svelte-check": "^4.0.0",
 		"typescript": "^5.0.0",

--- a/03-sveltekit-chrome-devtool/src/routes/+page.ts
+++ b/03-sveltekit-chrome-devtool/src/routes/+page.ts
@@ -1,12 +1,12 @@
 /** @type {import('./$types').PageLoad} */
 
+
 export async function load({ fetch }) {
     // Get the balance from API
 	const balance = await fetch('/api/balance?startMonth=2024-9&endMonth=2024-11',
         {
             method: 'GET',
             headers: {
-                'X-API-KEY': 'fcb03a6e-9861-4608-9b30-13b09127dfd7',
                 'Content-Type': 'application/json'
             }
         }
@@ -19,7 +19,6 @@ export async function load({ fetch }) {
         {
             method: 'GET',
             headers: {
-                'X-API-KEY': 'fcb03a6e-9861-4608-9b30-13b09127dfd7',
                 'Content-Type': 'application/json'
             }
         }

--- a/03-sveltekit-chrome-devtool/vite.config.ts
+++ b/03-sveltekit-chrome-devtool/vite.config.ts
@@ -1,16 +1,22 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 
-export default defineConfig({
-	plugins: [sveltekit()],
-	server: {
-		proxy: {
-			'/api': {
-				target: 'https://payment-incubator.apps.dev.cborbit.dev',
-				changeOrigin: true,
-				secure: false,
-				ws: true,
-				rewrite: (p) => p.replace(/^\/api/, '')
+export default defineConfig(({ command, mode }) => {
+	const { API_KEY } = loadEnv(mode, process.cwd(), '')
+	return {
+		plugins: [sveltekit()],
+		server: {
+			proxy: {
+				'/api': {
+					target: 'https://payment-incubator.apps.dev.cborbit.dev',
+					changeOrigin: true,
+					secure: false,
+					ws: true,
+					rewrite: (p) => p.replace(/^\/api/, ''),
+					headers: {
+						'X-API-KEY': API_KEY
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
…also put the API_KEY in .env

This PR is just a suggestion on how we could avoid exposing the API_KEY in the client code. We can show how we put secret information into .env file to hide it from being checked in.

Just an idea; ignore if you (Paul) have other plans ;) 